### PR TITLE
Fused spec dictum key and dictum_description key

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ describe V1::MyResourceController do
 
   describe '#some_method' do
     context 'some context for my resource' do
-      it 'returns status ok', dictum: true, dictum_description: 'This optional property exists to add a description to the endpoint.' do
+      it 'returns status ok', dictum: 'This property exists to add a description to the endpoint. If you do not want a description, just set it to true' do
         get :index
         expect(response_status).to eq(200)
       end

--- a/lib/dictum/documenter.rb
+++ b/lib/dictum/documenter.rb
@@ -21,7 +21,7 @@ module Dictum
       description = arguments[:description]
       return if name.nil?
       resources[name] ||= {}
-      resources[name][:description] = description if description
+      resources[name][:description] = description if description && description.is_a?(String)
       resources[name][:endpoints] ||= []
       update_temp
     end

--- a/lib/dictum/markdown_writer.rb
+++ b/lib/dictum/markdown_writer.rb
@@ -24,7 +24,7 @@ module Dictum
 
     def write_index
       output_file.puts "# #{@config[:index_title]}"
-      @temp_json['resources'].each do |resource_name, _information|
+      @temp_json['resources'].each_key do |resource_name|
         output_file.puts "- #{resource_name}"
       end
       output_file.puts "\n"

--- a/lib/tasks/default_configuration
+++ b/lib/tasks/default_configuration
@@ -12,7 +12,7 @@ RSpec.configure do |config|
       resource: test.metadata[:described_class].to_s.split('::').last.gsub('Controller', ''),
       endpoint: request.fullpath,
       http_verb: request.env['REQUEST_METHOD'],
-      description: test.metadata[:dictum_description],
+      description: test.metadata[:dictum],
       request_headers: DEFAULT_REQUEST_HEADERS,
       request_path_parameters: request.env['action_dispatch.request.path_parameters'].except(:controller, :action),
       request_body_parameters: request.env['action_dispatch.request.parameters'].except('controller', 'action'),

--- a/spec/html_writer_spec.rb
+++ b/spec/html_writer_spec.rb
@@ -25,7 +25,7 @@ describe 'Dictum::HtmlWriter' do
 
     it 'creates the resources files with correct names' do
       json = JSON.parse(File.open(temp_path).read)
-      json['resources'].each do |resource, _information|
+      json['resources'].each_key do |resource|
         expect(File.exist?("./spec/temp/docs/#{resource.downcase}.html")).to be_truthy
       end
     end


### PR DESCRIPTION
## Summary
Fused spec dictum key and dictum_description key so people can do:
```ruby
it 'returns status ok', dictum: 'foo'
end
```
instead of
```ruby
it 'returns status ok', dictum: true, dictum_description: 'foo'
end
```